### PR TITLE
Improve operation summaries and add field descriptions

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -39,7 +39,7 @@ public isolated client class Client {
         self.clientEp = check new (serviceUrl, httpClientConfig);
     }
 
-    # Read a batch of orders by internal ID, or unique property values
+    # Read a batch of orders by ID
     #
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
@@ -58,8 +58,9 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Read
+    # Retrieve an order by ID
     #
+    # + orderId - The unique identifier of the order to retrieve.
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -75,8 +76,9 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Archive
+    # Archive an order by ID
     #
+    # + orderId - The unique identifier of the order to delete.
     # + headers - Headers to be sent with the request 
     # + return - No content 
     resource isolated function delete [string orderId](map<string|string[]> headers = {}) returns error? {
@@ -89,8 +91,9 @@ public isolated client class Client {
         return self.clientEp->delete(resourcePath, headers = httpHeaders);
     }
 
-    # Update
+    # Update an order by ID
     #
+    # + orderId - The unique identifier of the order to update.
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -159,7 +162,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # List
+    # List all orders
     #
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
@@ -176,7 +179,7 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Create
+    # Create a new order
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
@@ -193,7 +196,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Create or update a batch of orders by unique property values
+    # Upsert orders by property values
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
@@ -210,6 +213,8 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
+    # Search orders
+    #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     resource isolated function post search(PublicObjectSearchRequest payload, map<string|string[]> headers = {}) returns CollectionResponseWithTotalSimplePublicObjectForwardPaging|error {

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -23,7 +23,7 @@ import ballerina/http;
 public isolated client class Client {
     final http:Client clientEp;
     final readonly & ApiKeysConfig? apiKeyConfig;
-    # Gets invoked to initialize the `connector`.
+    # Gets invoked to initialize the `connector`
     #
     # + config - The configurations to be used when initializing the `connector` 
     # + serviceUrl - URL of the target service 
@@ -60,7 +60,7 @@ public isolated client class Client {
 
     # Retrieve an order by ID
     #
-    # + orderId - The unique identifier of the order to retrieve.
+    # + orderId - The unique identifier of the order to retrieve
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -78,7 +78,7 @@ public isolated client class Client {
 
     # Archive an order by ID
     #
-    # + orderId - The unique identifier of the order to delete.
+    # + orderId - The unique identifier of the order to delete
     # + headers - Headers to be sent with the request 
     # + return - No content 
     resource isolated function delete [string orderId](map<string|string[]> headers = {}) returns error? {
@@ -93,7 +93,7 @@ public isolated client class Client {
 
     # Update an order by ID
     #
-    # + orderId - The unique identifier of the order to update.
+    # + orderId - The unique identifier of the order to update
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -19,23 +19,23 @@
 
 import ballerina/http;
 
-# Standard error response structure returned by the Orders API.
+# Standard error response structure returned by the Orders API
 public type StandardError record {
-    # Optional sub-category providing additional error classification.
+    # Optional sub-category providing additional error classification
     record {} subCategory?;
-    # Contextual metadata map with string array values for the error.
+    # Contextual metadata map with string array values for the error
     record {|string[]...;|} context;
-    # Map of relevant links associated with the error response.
+    # Map of relevant links associated with the error response
     record {|string...;|} links;
-    # Unique identifier for the error instance.
+    # Unique identifier for the error instance
     string id?;
-    # High-level category classifying the type of error.
+    # High-level category classifying the type of error
     string category;
-    # Human-readable message describing the error.
+    # Human-readable message describing the error
     string message;
-    # List of detailed error objects providing granular error info.
+    # List of detailed error objects providing granular error info
     ErrorDetail[] errors;
-    # HTTP status code or status string associated with the error.
+    # HTTP status code or status string associated with the error
     string status;
 };
 
@@ -53,11 +53,11 @@ public type GetCrmV3ObjectsOrdersOrderIdQueries record {
     string[] properties?;
 };
 
-# Paginated collection of associated object IDs.
+# Paginated collection of associated object IDs
 public type CollectionResponseAssociatedId record {
-    # Pagination object containing cursors for navigating to the next or previous result page.
+    # Pagination object containing cursors for navigating to the next or previous result page
     Paging paging?;
-    # Array of associated object IDs returned in the response.
+    # Array of associated object IDs returned in the response
     AssociatedId[] results;
 };
 
@@ -77,37 +77,37 @@ public type GetCrmV3ObjectsOrdersQueries record {
     string[] properties?;
 };
 
-# Defines association targets and their types for a given object.
+# Defines association targets and their types for a given object
 public type PublicAssociationsForObject record {
-    # List of association type specifications for the relationship.
+    # List of association type specifications for the relationship
     AssociationSpec[] types;
-    # Represents a public object identifier containing a unique ID string.
+    # Represents a public object identifier containing a unique ID string
     PublicObjectId to;
 };
 
-# Batch operation response containing results and processing status.
+# Batch operation response containing results and processing status
 public type BatchResponseSimplePublicObject record {
-    # Timestamp indicating when the batch operation completed.
+    # Timestamp indicating when the batch operation completed
     string completedAt;
-    # Timestamp indicating when the batch operation was requested.
+    # Timestamp indicating when the batch operation was requested
     string requestedAt?;
-    # Timestamp indicating when the batch operation started processing.
+    # Timestamp indicating when the batch operation started processing
     string startedAt;
-    # Map of relevant links associated with the batch response.
+    # Map of relevant links associated with the batch response
     record {|string...;|} links?;
-    # Array of order objects returned by the batch operation.
+    # Array of order objects returned by the batch operation
     SimplePublicObject[] results;
-    # Current processing status of the batch request.
+    # Current processing status of the batch request
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
-# A logical grouping of filters applied together when searching orders.
+# A logical grouping of filters applied together when searching orders
 public type FilterGroup record {
-    # Array of filter conditions within this group.
+    # Array of filter conditions within this group
     Filter[] filters;
 };
 
-# Detailed information about a specific error encountered during a request.
+# Detailed information about a specific error encountered during a request
 public type ErrorDetail record {
     # A specific category that contains more specific detail about the error
     string subCategory?;
@@ -121,85 +121,85 @@ public type ErrorDetail record {
     string message;
 };
 
-# Pagination metadata for forward-only cursor-based navigation.
+# Pagination metadata for forward-only cursor-based navigation
 public type ForwardPaging record {
-    # Pagination cursor details for retrieving the next page of results.
+    # Pagination cursor details for retrieving the next page of results
     NextPage next?;
 };
 
-# A minimal object representation containing only a unique identifier.
+# A minimal object representation containing only a unique identifier
 public type SimplePublicObjectId record {
-    # The unique identifier of the object.
+    # The unique identifier of the object
     string id;
 };
 
-# Batch upsert response including results, errors, and processing status details.
+# Batch upsert response including results, errors, and processing status details
 public type BatchResponseSimplePublicUpsertObjectWithErrors record {
-    # Timestamp when the batch operation completed.
+    # Timestamp when the batch operation completed
     string completedAt;
-    # Total number of errors encountered during the batch operation.
+    # Total number of errors encountered during the batch operation
     int:Signed32 numErrors?;
-    # Timestamp when the batch operation was requested.
+    # Timestamp when the batch operation was requested
     string requestedAt?;
-    # Timestamp when the batch operation began processing.
+    # Timestamp when the batch operation began processing
     string startedAt;
-    # Map of relevant hyperlinks associated with the batch response.
+    # Map of relevant hyperlinks associated with the batch response
     record {|string...;|} links?;
-    # Array of successfully upserted order objects.
+    # Array of successfully upserted order objects
     SimplePublicUpsertObject[] results;
-    # Array of errors encountered for individual records in the batch.
+    # Array of errors encountered for individual records in the batch
     StandardError[] errors?;
-    # Current processing status of the batch upsert request.
+    # Current processing status of the batch upsert request
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
-# Input payload for batch reading orders by ID, including requested properties.
+# Input payload for batch reading orders by ID, including requested properties
 public type BatchReadInputSimplePublicObjectId record {
-    # List of properties for which historical values should be returned.
+    # List of properties for which historical values should be returned
     string[] propertiesWithHistory;
-    # The property to use as the unique identifier for lookup.
+    # The property to use as the unique identifier for lookup
     string idProperty?;
-    # List of object IDs to retrieve in the batch read.
+    # List of object IDs to retrieve in the batch read
     SimplePublicObjectId[] inputs;
-    # List of property names to include in the response.
+    # List of property names to include in the response
     string[] properties;
 };
 
-# Response object containing the status, timing, and results of a batch upsert operation.
+# Response object containing the status, timing, and results of a batch upsert operation
 public type BatchResponseSimplePublicUpsertObject record {
-    # Timestamp indicating when the batch operation completed.
+    # Timestamp indicating when the batch operation completed
     string completedAt;
-    # Timestamp indicating when the batch operation was requested.
+    # Timestamp indicating when the batch operation was requested
     string requestedAt?;
-    # Timestamp indicating when the batch operation started.
+    # Timestamp indicating when the batch operation started
     string startedAt;
-    # Map of relevant links associated with the batch response.
+    # Map of relevant links associated with the batch response
     record {|string...;|} links?;
-    # List of upserted objects returned by the batch operation.
+    # List of upserted objects returned by the batch operation
     SimplePublicUpsertObject[] results;
-    # Current processing status of the batch operation.
+    # Current processing status of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
-# A property value paired with its source metadata and the timestamp of the last update.
+# A property value paired with its source metadata and the timestamp of the last update
 public type ValueWithTimestamp record {
-    # Identifier of the source that set this value.
+    # Identifier of the source that set this value
     string sourceId?;
-    # Type of source that originated this value.
+    # Type of source that originated this value
     string sourceType;
-    # Human-readable label describing the value's source.
+    # Human-readable label describing the value's source
     string sourceLabel?;
-    # ID of the user who last updated this value.
+    # ID of the user who last updated this value
     int:Signed32 updatedByUserId?;
-    # The property value as a string.
+    # The property value as a string
     string value;
-    # Timestamp indicating when the value was last updated.
+    # Timestamp indicating when the value was last updated
     string timestamp;
 };
 
-# Input schema containing a list of object IDs for a batch operation.
+# Input schema containing a list of object IDs for a batch operation
 public type BatchInputSimplePublicObjectId record {
-    # List of object IDs to process in the batch operation.
+    # List of object IDs to process in the batch operation
     SimplePublicObjectId[] inputs;
 };
 
@@ -216,44 +216,44 @@ public type PostCrmV3ObjectsOrdersBatchReadQueries record {
     boolean archived = false;
 };
 
-# Input schema containing a list of objects to create or update in a batch upsert operation.
+# Input schema containing a list of objects to create or update in a batch upsert operation
 public type BatchInputSimplePublicObjectBatchInputUpsert record {
-    # Array of order objects to upsert in batch.
+    # Array of order objects to upsert in batch
     SimplePublicObjectBatchInputUpsert[] inputs;
 };
 
-# A paginated collection of order objects with a total count and forward paging cursor.
+# A paginated collection of order objects with a total count and forward paging cursor
 public type CollectionResponseWithTotalSimplePublicObjectForwardPaging record {
-    # Total number of orders matching the request.
+    # Total number of orders matching the request
     int:Signed32 total;
-    # Pagination metadata for forward-only cursor-based navigation.
+    # Pagination metadata for forward-only cursor-based navigation
     ForwardPaging paging?;
-    # Array of order objects returned in the current page.
+    # Array of order objects returned in the current page
     SimplePublicObject[] results;
 };
 
-# Represents a single order object with its properties, metadata, and optional history.
+# Represents a single order object with its properties, metadata, and optional history
 public type SimplePublicObject record {
-    # Timestamp when the order was created.
+    # Timestamp when the order was created
     string createdAt;
-    # Indicates whether the order is archived.
+    # Indicates whether the order is archived
     boolean archived?;
-    # Timestamp when the order was archived.
+    # Timestamp when the order was archived
     string archivedAt?;
-    # Map of order properties including their historical values with timestamps.
+    # Map of order properties including their historical values with timestamps
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
-    # Unique identifier of the order object.
+    # Unique identifier of the order object
     string id;
-    # Map of order property names to their current values.
+    # Map of order property names to their current values
     record {|string?...;|} properties;
-    # Timestamp when the order was last updated.
+    # Timestamp when the order was last updated
     string updatedAt;
 };
 
-# Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.
+# Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint
 @display {label: "Connection Config"}
 public type ConnectionConfig record {|
-    # Provides Auth configurations needed when communicating with a remote HTTP endpoint.
+    # Provides Auth configurations needed when communicating with a remote HTTP endpoint
     http:BearerTokenConfig|OAuth2RefreshTokenGrantConfig|ApiKeysConfig auth;
     # The HTTP version understood by the client
     http:HttpVersion httpVersion = http:HTTP_2_0;
@@ -290,113 +290,113 @@ public type ConnectionConfig record {|
     # Enables the inbound payload validation functionality which provided by the constraint package. Enabled by default
     boolean validation = true;
     # Enables relaxed data binding on the client side. When enabled, `nil` values are treated as optional, 
-    # and absent fields are handled as `nilable` types. Enabled by default.
+    # and absent fields are handled as `nilable` types. Enabled by default
     boolean laxDataBinding = true;
 |};
 
-# Represents a public object identifier containing a unique ID string.
+# Represents a public object identifier containing a unique ID string
 public type PublicObjectId record {
-    # Unique identifier of the public object.
+    # Unique identifier of the public object
     string id;
 };
 
-# Pagination object containing cursors for navigating to the next or previous result page.
+# Pagination object containing cursors for navigating to the next or previous result page
 public type Paging record {
-    # Pagination cursor details for retrieving the next page of results.
+    # Pagination cursor details for retrieving the next page of results
     NextPage next?;
-    # Pagination cursor details for navigating to the previous page of results.
+    # Pagination cursor details for navigating to the previous page of results
     PreviousPage prev?;
 };
 
-# Request payload for searching orders with filters, sorting, and pagination options.
+# Request payload for searching orders with filters, sorting, and pagination options
 public type PublicObjectSearchRequest record {
-    # Full-text search query string to match against order records.
+    # Full-text search query string to match against order records
     string query?;
-    # Maximum number of results to return in the response.
+    # Maximum number of results to return in the response
     int:Signed32 'limit?;
-    # Cursor token for retrieving the next page of results.
+    # Cursor token for retrieving the next page of results
     string after?;
-    # List of property names to sort results by.
+    # List of property names to sort results by
     string[] sorts?;
-    # List of property names to include in the response.
+    # List of property names to include in the response
     string[] properties?;
-    # Groups of filters to apply when narrowing search results.
+    # Groups of filters to apply when narrowing search results
     FilterGroup[] filterGroups?;
 };
 
-# Input object for upserting an order, containing an identifier and a map of property values.
+# Input object for upserting an order, containing an identifier and a map of property values
 public type SimplePublicObjectBatchInputUpsert record {
-    # The property name used as the unique identifier for the upsert.
+    # The property name used as the unique identifier for the upsert
     string idProperty?;
-    # Trace identifier for tracking the write operation.
+    # Trace identifier for tracking the write operation
     string objectWriteTraceId?;
-    # The unique identifier of the order to upsert.
+    # The unique identifier of the order to upsert
     string id;
-    # Key-value map of order property names and their values.
+    # Key-value map of order property names and their values
     record {|string...;|} properties;
 };
 
-# Batch operation response containing results, status, timestamps, and any errors encountered.
+# Batch operation response containing results, status, timestamps, and any errors encountered
 public type BatchResponseSimplePublicObjectWithErrors record {
-    # Timestamp indicating when the batch operation completed.
+    # Timestamp indicating when the batch operation completed
     string completedAt;
-    # Total number of errors encountered during the batch operation.
+    # Total number of errors encountered during the batch operation
     int:Signed32 numErrors?;
-    # Timestamp indicating when the batch operation was requested.
+    # Timestamp indicating when the batch operation was requested
     string requestedAt?;
-    # Timestamp indicating when the batch operation started processing.
+    # Timestamp indicating when the batch operation started processing
     string startedAt;
-    # Map of relevant link names to associated URIs for the response.
+    # Map of relevant link names to associated URIs for the response
     record {|string...;|} links?;
-    # List of successfully processed order objects from the batch.
+    # List of successfully processed order objects from the batch
     SimplePublicObject[] results;
-    # List of errors encountered for individual records in the batch.
+    # List of errors encountered for individual records in the batch
     StandardError[] errors?;
-    # Current processing status of the batch operation.
+    # Current processing status of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
-# Input schema for creating or updating an order object with properties and associations.
+# Input schema for creating or updating an order object with properties and associations
 public type SimplePublicObjectInput record {
-    # Trace identifier for tracking the write operation.
+    # Trace identifier for tracking the write operation
     string objectWriteTraceId?;
-    # Key-value map of order property names and their string values.
+    # Key-value map of order property names and their string values
     record {|string...;|} properties;
 };
 
-# Paginated collection of order objects including their associated records.
+# Paginated collection of order objects including their associated records
 public type CollectionResponseSimplePublicObjectWithAssociationsForwardPaging record {
-    # Pagination metadata for forward-only cursor-based navigation.
+    # Pagination metadata for forward-only cursor-based navigation
     ForwardPaging paging?;
-    # Array of order objects returned in the current page.
+    # Array of order objects returned in the current page
     SimplePublicObjectWithAssociations[] results;
 };
 
-# Defines the category and type of an association between two objects.
+# Defines the category and type of an association between two objects
 public type AssociationSpec record {
-    # Category of the association: HUBSPOT_DEFINED, USER_DEFINED, or INTEGRATOR_DEFINED.
+    # Category of the association: HUBSPOT_DEFINED, USER_DEFINED, or INTEGRATOR_DEFINED
     "HUBSPOT_DEFINED"|"USER_DEFINED"|"INTEGRATOR_DEFINED" associationCategory;
-    # Numeric identifier for the specific association type.
+    # Numeric identifier for the specific association type
     int:Signed32 associationTypeId;
 };
 
-# An order object including its properties, metadata, and associated records.
+# An order object including its properties, metadata, and associated records
 public type SimplePublicObjectWithAssociations record {
-    # Map of associated object collections keyed by association type.
+    # Map of associated object collections keyed by association type
     record {|CollectionResponseAssociatedId...;|} associations?;
-    # Timestamp when the order record was created.
+    # Timestamp when the order record was created
     string createdAt;
-    # Indicates whether the order record is archived.
+    # Indicates whether the order record is archived
     boolean archived?;
-    # Timestamp when the order record was archived.
+    # Timestamp when the order record was archived
     string archivedAt?;
-    # Map of property names to their historical values with timestamps.
+    # Map of property names to their historical values with timestamps
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
-    # Unique identifier of the order record.
+    # Unique identifier of the order record
     string id;
-    # Key-value map of the order's current property names and values.
+    # Key-value map of the order's current property names and values
     record {|string?...;|} properties;
-    # Timestamp when the order record was last updated.
+    # Timestamp when the order record was last updated
     string updatedAt;
 };
 
@@ -406,100 +406,100 @@ public type PatchCrmV3ObjectsOrdersOrderIdQueries record {
     string idProperty?;
 };
 
-# Defines a filter condition using a property, operator, and comparison value.
+# Defines a filter condition using a property, operator, and comparison value
 public type Filter record {
-    # Upper bound value used with the BETWEEN operator.
+    # Upper bound value used with the BETWEEN operator
     string highValue?;
-    # The name of the property to filter by.
+    # The name of the property to filter by
     string propertyName;
-    # A list of values to match against the filter property.
+    # A list of values to match against the filter property
     string[] values?;
-    # The single value to match against the filter property.
+    # The single value to match against the filter property
     string value?;
-    # The comparison operator used to evaluate the filter condition.
+    # The comparison operator used to evaluate the filter condition
     "EQ"|"NEQ"|"LT"|"LTE"|"GT"|"GTE"|"BETWEEN"|"IN"|"NOT_IN"|"HAS_PROPERTY"|"NOT_HAS_PROPERTY"|"CONTAINS_TOKEN"|"NOT_CONTAINS_TOKEN" operator;
 };
 
-# Pagination cursor details for navigating to the previous page of results.
+# Pagination cursor details for navigating to the previous page of results
 public type PreviousPage record {
-    # The cursor token representing the start of the previous page.
+    # The cursor token representing the start of the previous page
     string before;
-    # The URL link to retrieve the previous page of results.
+    # The URL link to retrieve the previous page of results
     string link?;
 };
 
-# A batch input wrapper containing an array of objects to create.
+# A batch input wrapper containing an array of objects to create
 public type BatchInputSimplePublicObjectInputForCreate record {
-    # An array of objects to be created in the batch operation.
+    # An array of objects to be created in the batch operation
     SimplePublicObjectInputForCreate[] inputs;
 };
 
-# A batch input wrapper containing an array of objects to update.
+# A batch input wrapper containing an array of objects to update
 public type BatchInputSimplePublicObjectBatchInput record {
-    # An array of objects to be updated in the batch operation.
+    # An array of objects to be updated in the batch operation
     SimplePublicObjectBatchInput[] inputs;
 };
 
-# Represents an order object returned after an upsert operation, including metadata and property values.
+# Represents an order object returned after an upsert operation, including metadata and property values
 public type SimplePublicUpsertObject record {
-    # The timestamp when the object was created.
+    # The timestamp when the object was created
     string createdAt;
-    # Indicates whether the object is archived.
+    # Indicates whether the object is archived
     boolean archived?;
-    # The timestamp when the object was archived.
+    # The timestamp when the object was archived
     string archivedAt?;
-    # Indicates whether the object was newly created by the upsert.
+    # Indicates whether the object was newly created by the upsert
     boolean 'new;
-    # A map of property names to their historical values with timestamps.
+    # A map of property names to their historical values with timestamps
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
-    # The unique identifier of the object.
+    # The unique identifier of the object
     string id;
-    # A map of property names to their current string values.
+    # A map of property names to their current string values
     record {|string...;|} properties;
-    # The timestamp when the object was last updated.
+    # The timestamp when the object was last updated
     string updatedAt;
 };
 
-# Input schema for updating a single order in a batch operation.
+# Input schema for updating a single order in a batch operation
 public type SimplePublicObjectBatchInput record {
-    # The property name used as the unique identifier for the order.
+    # The property name used as the unique identifier for the order
     string idProperty?;
-    # Trace ID for tracking the write operation.
+    # Trace ID for tracking the write operation
     string objectWriteTraceId?;
-    # The unique identifier of the order to update.
+    # The unique identifier of the order to update
     string id;
-    # Key-value pairs of order properties to update.
+    # Key-value pairs of order properties to update
     record {|string...;|} properties;
 };
 
-# Pagination cursor details for retrieving the next page of results.
+# Pagination cursor details for retrieving the next page of results
 public type NextPage record {
-    # The URL query string to fetch the next page of results.
+    # The URL query string to fetch the next page of results
     string link?;
-    # The cursor token used to retrieve the next page of results.
+    # The cursor token used to retrieve the next page of results
     string after;
 };
 
-# Represents an associated object's ID and association type.
+# Represents an associated object's ID and association type
 public type AssociatedId record {
-    # The unique identifier of the associated object.
+    # The unique identifier of the associated object
     string id;
-    # The type of association between the objects.
+    # The type of association between the objects
     string 'type;
 };
 
-# Provides API key configurations needed when communicating with a remote HTTP endpoint.
+# Provides API key configurations needed when communicating with a remote HTTP endpoint
 public type ApiKeysConfig record {|
     string privateAppLegacy;
     string privateApp;
 |};
 
-# Input schema for creating a new order with properties and associations.
+# Input schema for creating a new order with properties and associations
 public type SimplePublicObjectInputForCreate record {
-    # List of associated objects to link to the new order.
+    # List of associated objects to link to the new order
     PublicAssociationsForObject[] associations;
-    # Trace ID for tracking the write operation.
+    # Trace ID for tracking the write operation
     string objectWriteTraceId?;
-    # Key-value pairs of order properties to set on creation.
+    # Key-value pairs of order properties to set on creation
     record {|string...;|} properties;
 };

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -19,14 +19,23 @@
 
 import ballerina/http;
 
+# Standard error response structure returned by the Orders API.
 public type StandardError record {
+    # Optional sub-category providing additional error classification.
     record {} subCategory?;
+    # Contextual metadata map with string array values for the error.
     record {|string[]...;|} context;
+    # Map of relevant links associated with the error response.
     record {|string...;|} links;
+    # Unique identifier for the error instance.
     string id?;
+    # High-level category classifying the type of error.
     string category;
+    # Human-readable message describing the error.
     string message;
+    # List of detailed error objects providing granular error info.
     ErrorDetail[] errors;
+    # HTTP status code or status string associated with the error.
     string status;
 };
 
@@ -44,8 +53,11 @@ public type GetCrmV3ObjectsOrdersOrderIdQueries record {
     string[] properties?;
 };
 
+# Paginated collection of associated object IDs.
 public type CollectionResponseAssociatedId record {
+    # Pagination object containing cursors for navigating to the next or previous result page.
     Paging paging?;
+    # Array of associated object IDs returned in the response.
     AssociatedId[] results;
 };
 
@@ -65,24 +77,37 @@ public type GetCrmV3ObjectsOrdersQueries record {
     string[] properties?;
 };
 
+# Defines association targets and their types for a given object.
 public type PublicAssociationsForObject record {
+    # List of association type specifications for the relationship.
     AssociationSpec[] types;
+    # Represents a public object identifier containing a unique ID string.
     PublicObjectId to;
 };
 
+# Batch operation response containing results and processing status.
 public type BatchResponseSimplePublicObject record {
+    # Timestamp indicating when the batch operation completed.
     string completedAt;
+    # Timestamp indicating when the batch operation was requested.
     string requestedAt?;
+    # Timestamp indicating when the batch operation started processing.
     string startedAt;
+    # Map of relevant links associated with the batch response.
     record {|string...;|} links?;
+    # Array of order objects returned by the batch operation.
     SimplePublicObject[] results;
+    # Current processing status of the batch request.
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# A logical grouping of filters applied together when searching orders.
 public type FilterGroup record {
+    # Array of filter conditions within this group.
     Filter[] filters;
 };
 
+# Detailed information about a specific error encountered during a request.
 public type ErrorDetail record {
     # A specific category that contains more specific detail about the error
     string subCategory?;
@@ -96,51 +121,85 @@ public type ErrorDetail record {
     string message;
 };
 
+# Pagination metadata for forward-only cursor-based navigation.
 public type ForwardPaging record {
+    # Pagination cursor details for retrieving the next page of results.
     NextPage next?;
 };
 
+# A minimal object representation containing only a unique identifier.
 public type SimplePublicObjectId record {
+    # The unique identifier of the object.
     string id;
 };
 
+# Batch upsert response including results, errors, and processing status details.
 public type BatchResponseSimplePublicUpsertObjectWithErrors record {
+    # Timestamp when the batch operation completed.
     string completedAt;
+    # Total number of errors encountered during the batch operation.
     int:Signed32 numErrors?;
+    # Timestamp when the batch operation was requested.
     string requestedAt?;
+    # Timestamp when the batch operation began processing.
     string startedAt;
+    # Map of relevant hyperlinks associated with the batch response.
     record {|string...;|} links?;
+    # Array of successfully upserted order objects.
     SimplePublicUpsertObject[] results;
+    # Array of errors encountered for individual records in the batch.
     StandardError[] errors?;
+    # Current processing status of the batch upsert request.
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# Input payload for batch reading orders by ID, including requested properties.
 public type BatchReadInputSimplePublicObjectId record {
+    # List of properties for which historical values should be returned.
     string[] propertiesWithHistory;
+    # The property to use as the unique identifier for lookup.
     string idProperty?;
+    # List of object IDs to retrieve in the batch read.
     SimplePublicObjectId[] inputs;
+    # List of property names to include in the response.
     string[] properties;
 };
 
+# Response object containing the status, timing, and results of a batch upsert operation.
 public type BatchResponseSimplePublicUpsertObject record {
+    # Timestamp indicating when the batch operation completed.
     string completedAt;
+    # Timestamp indicating when the batch operation was requested.
     string requestedAt?;
+    # Timestamp indicating when the batch operation started.
     string startedAt;
+    # Map of relevant links associated with the batch response.
     record {|string...;|} links?;
+    # List of upserted objects returned by the batch operation.
     SimplePublicUpsertObject[] results;
+    # Current processing status of the batch operation.
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# A property value paired with its source metadata and the timestamp of the last update.
 public type ValueWithTimestamp record {
+    # Identifier of the source that set this value.
     string sourceId?;
+    # Type of source that originated this value.
     string sourceType;
+    # Human-readable label describing the value's source.
     string sourceLabel?;
+    # ID of the user who last updated this value.
     int:Signed32 updatedByUserId?;
+    # The property value as a string.
     string value;
+    # Timestamp indicating when the value was last updated.
     string timestamp;
 };
 
+# Input schema containing a list of object IDs for a batch operation.
 public type BatchInputSimplePublicObjectId record {
+    # List of object IDs to process in the batch operation.
     SimplePublicObjectId[] inputs;
 };
 
@@ -157,23 +216,37 @@ public type PostCrmV3ObjectsOrdersBatchReadQueries record {
     boolean archived = false;
 };
 
+# Input schema containing a list of objects to create or update in a batch upsert operation.
 public type BatchInputSimplePublicObjectBatchInputUpsert record {
+    # Array of order objects to upsert in batch.
     SimplePublicObjectBatchInputUpsert[] inputs;
 };
 
+# A paginated collection of order objects with a total count and forward paging cursor.
 public type CollectionResponseWithTotalSimplePublicObjectForwardPaging record {
+    # Total number of orders matching the request.
     int:Signed32 total;
+    # Pagination metadata for forward-only cursor-based navigation.
     ForwardPaging paging?;
+    # Array of order objects returned in the current page.
     SimplePublicObject[] results;
 };
 
+# Represents a single order object with its properties, metadata, and optional history.
 public type SimplePublicObject record {
+    # Timestamp when the order was created.
     string createdAt;
+    # Indicates whether the order is archived.
     boolean archived?;
+    # Timestamp when the order was archived.
     string archivedAt?;
+    # Map of order properties including their historical values with timestamps.
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
+    # Unique identifier of the order object.
     string id;
+    # Map of order property names to their current values.
     record {|string?...;|} properties;
+    # Timestamp when the order was last updated.
     string updatedAt;
 };
 
@@ -221,65 +294,109 @@ public type ConnectionConfig record {|
     boolean laxDataBinding = true;
 |};
 
+# Represents a public object identifier containing a unique ID string.
 public type PublicObjectId record {
+    # Unique identifier of the public object.
     string id;
 };
 
+# Pagination object containing cursors for navigating to the next or previous result page.
 public type Paging record {
+    # Pagination cursor details for retrieving the next page of results.
     NextPage next?;
+    # Pagination cursor details for navigating to the previous page of results.
     PreviousPage prev?;
 };
 
+# Request payload for searching orders with filters, sorting, and pagination options.
 public type PublicObjectSearchRequest record {
+    # Full-text search query string to match against order records.
     string query?;
+    # Maximum number of results to return in the response.
     int:Signed32 'limit?;
+    # Cursor token for retrieving the next page of results.
     string after?;
+    # List of property names to sort results by.
     string[] sorts?;
+    # List of property names to include in the response.
     string[] properties?;
+    # Groups of filters to apply when narrowing search results.
     FilterGroup[] filterGroups?;
 };
 
+# Input object for upserting an order, containing an identifier and a map of property values.
 public type SimplePublicObjectBatchInputUpsert record {
+    # The property name used as the unique identifier for the upsert.
     string idProperty?;
+    # Trace identifier for tracking the write operation.
     string objectWriteTraceId?;
+    # The unique identifier of the order to upsert.
     string id;
+    # Key-value map of order property names and their values.
     record {|string...;|} properties;
 };
 
+# Batch operation response containing results, status, timestamps, and any errors encountered.
 public type BatchResponseSimplePublicObjectWithErrors record {
+    # Timestamp indicating when the batch operation completed.
     string completedAt;
+    # Total number of errors encountered during the batch operation.
     int:Signed32 numErrors?;
+    # Timestamp indicating when the batch operation was requested.
     string requestedAt?;
+    # Timestamp indicating when the batch operation started processing.
     string startedAt;
+    # Map of relevant link names to associated URIs for the response.
     record {|string...;|} links?;
+    # List of successfully processed order objects from the batch.
     SimplePublicObject[] results;
+    # List of errors encountered for individual records in the batch.
     StandardError[] errors?;
+    # Current processing status of the batch operation.
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# Input schema for creating or updating an order object with properties and associations.
 public type SimplePublicObjectInput record {
+    # Trace identifier for tracking the write operation.
     string objectWriteTraceId?;
+    # Key-value map of order property names and their string values.
     record {|string...;|} properties;
 };
 
+# Paginated collection of order objects including their associated records.
 public type CollectionResponseSimplePublicObjectWithAssociationsForwardPaging record {
+    # Pagination metadata for forward-only cursor-based navigation.
     ForwardPaging paging?;
+    # Array of order objects returned in the current page.
     SimplePublicObjectWithAssociations[] results;
 };
 
+# Defines the category and type of an association between two objects.
 public type AssociationSpec record {
+    # Category of the association: HUBSPOT_DEFINED, USER_DEFINED, or INTEGRATOR_DEFINED.
     "HUBSPOT_DEFINED"|"USER_DEFINED"|"INTEGRATOR_DEFINED" associationCategory;
+    # Numeric identifier for the specific association type.
     int:Signed32 associationTypeId;
 };
 
+# An order object including its properties, metadata, and associated records.
 public type SimplePublicObjectWithAssociations record {
+    # Map of associated object collections keyed by association type.
     record {|CollectionResponseAssociatedId...;|} associations?;
+    # Timestamp when the order record was created.
     string createdAt;
+    # Indicates whether the order record is archived.
     boolean archived?;
+    # Timestamp when the order record was archived.
     string archivedAt?;
+    # Map of property names to their historical values with timestamps.
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
+    # Unique identifier of the order record.
     string id;
+    # Key-value map of the order's current property names and values.
     record {|string?...;|} properties;
+    # Timestamp when the order record was last updated.
     string updatedAt;
 };
 
@@ -289,53 +406,85 @@ public type PatchCrmV3ObjectsOrdersOrderIdQueries record {
     string idProperty?;
 };
 
+# Defines a filter condition using a property, operator, and comparison value.
 public type Filter record {
+    # Upper bound value used with the BETWEEN operator.
     string highValue?;
+    # The name of the property to filter by.
     string propertyName;
+    # A list of values to match against the filter property.
     string[] values?;
+    # The single value to match against the filter property.
     string value?;
-    # null
+    # The comparison operator used to evaluate the filter condition.
     "EQ"|"NEQ"|"LT"|"LTE"|"GT"|"GTE"|"BETWEEN"|"IN"|"NOT_IN"|"HAS_PROPERTY"|"NOT_HAS_PROPERTY"|"CONTAINS_TOKEN"|"NOT_CONTAINS_TOKEN" operator;
 };
 
+# Pagination cursor details for navigating to the previous page of results.
 public type PreviousPage record {
+    # The cursor token representing the start of the previous page.
     string before;
+    # The URL link to retrieve the previous page of results.
     string link?;
 };
 
+# A batch input wrapper containing an array of objects to create.
 public type BatchInputSimplePublicObjectInputForCreate record {
+    # An array of objects to be created in the batch operation.
     SimplePublicObjectInputForCreate[] inputs;
 };
 
+# A batch input wrapper containing an array of objects to update.
 public type BatchInputSimplePublicObjectBatchInput record {
+    # An array of objects to be updated in the batch operation.
     SimplePublicObjectBatchInput[] inputs;
 };
 
+# Represents an order object returned after an upsert operation, including metadata and property values.
 public type SimplePublicUpsertObject record {
+    # The timestamp when the object was created.
     string createdAt;
+    # Indicates whether the object is archived.
     boolean archived?;
+    # The timestamp when the object was archived.
     string archivedAt?;
+    # Indicates whether the object was newly created by the upsert.
     boolean 'new;
+    # A map of property names to their historical values with timestamps.
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
+    # The unique identifier of the object.
     string id;
+    # A map of property names to their current string values.
     record {|string...;|} properties;
+    # The timestamp when the object was last updated.
     string updatedAt;
 };
 
+# Input schema for updating a single order in a batch operation.
 public type SimplePublicObjectBatchInput record {
+    # The property name used as the unique identifier for the order.
     string idProperty?;
+    # Trace ID for tracking the write operation.
     string objectWriteTraceId?;
+    # The unique identifier of the order to update.
     string id;
+    # Key-value pairs of order properties to update.
     record {|string...;|} properties;
 };
 
+# Pagination cursor details for retrieving the next page of results.
 public type NextPage record {
+    # The URL query string to fetch the next page of results.
     string link?;
+    # The cursor token used to retrieve the next page of results.
     string after;
 };
 
+# Represents an associated object's ID and association type.
 public type AssociatedId record {
+    # The unique identifier of the associated object.
     string id;
+    # The type of association between the objects.
     string 'type;
 };
 
@@ -345,8 +494,12 @@ public type ApiKeysConfig record {|
     string privateApp;
 |};
 
+# Input schema for creating a new order with properties and associations.
 public type SimplePublicObjectInputForCreate record {
+    # List of associated objects to link to the new order.
     PublicAssociationsForObject[] associations;
+    # Trace ID for tracking the write operation.
     string objectWriteTraceId?;
+    # Key-value pairs of order properties to set on creation.
     record {|string...;|} properties;
 };

--- a/docs/spec/aligned_ballerina_openapi.json
+++ b/docs/spec/aligned_ballerina_openapi.json
@@ -1,0 +1,2107 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Orders",
+        "description": "",
+        "version": "v3",
+        "x-hubspot-product-tier-requirements": {
+            "marketing": "FREE",
+            "sales": "FREE",
+            "service": "FREE",
+            "cms": "FREE"
+        },
+        "x-hubspot-documentation-banner": "NONE",
+        "x-hubspot-api-use-case": "When a buyer adds a set of products to their cart and makes a purchase, store it as an individual order. You can then update the order with tracking information once the shipping label has been printed.",
+        "x-hubspot-related-documentation": [
+            {
+                "name": "Orders overview",
+                "url": "https://developers.hubspot.com/beta-docs/guides/api/crm/commerce/orders"
+            }
+        ],
+        "x-hubspot-introduction": "Use the orders API to create and manage data related to ecommerce purchases in HubSpot. This can be especially useful for keeping HubSpot data synced with external ecommerce platforms, such as Shopify and NetSuite."
+    },
+    "servers": [
+        {
+            "url": "https://api.hubapi.com/crm/v3/objects/orders"
+        }
+    ],
+    "tags": [
+        {
+            "name": "Batch"
+        },
+        {
+            "name": "Basic"
+        },
+        {
+            "name": "Search"
+        }
+    ],
+    "paths": {
+        "/batch/read": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Read a batch of orders by ID",
+                "operationId": "post-/crm/v3/objects/orders/batch/read",
+                "parameters": [
+                    {
+                        "name": "archived",
+                        "in": "query",
+                        "description": "Whether to return only results that have been archived",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchReadInputSimplePublicObjectId"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.orders.read"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.orders.read"
+                        ]
+                    }
+                ],
+                "description": "Returns a batch of orders matching the provided internal IDs or unique property values, with partial success indicated by a 207 response."
+            }
+        },
+        "/{orderId}": {
+            "get": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Retrieve an order by ID",
+                "description": "Read an Object identified by `{orderId}`. `{orderId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.",
+                "operationId": "get-/crm/v3/objects/orders/{orderId}",
+                "parameters": [
+                    {
+                        "name": "orderId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the order to retrieve."
+                    },
+                    {
+                        "name": "properties",
+                        "in": "query",
+                        "description": "A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "propertiesWithHistory",
+                        "in": "query",
+                        "description": "A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "associations",
+                        "in": "query",
+                        "description": "A comma separated list of object types to retrieve associated IDs for. If any of the specified associations do not exist, they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "archived",
+                        "in": "query",
+                        "description": "Whether to return only results that have been archived",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "idProperty",
+                        "in": "query",
+                        "description": "The name of a property whose values are unique for this object type",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimplePublicObjectWithAssociations"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.orders.read"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.orders.read"
+                        ]
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Archive an order by ID",
+                "description": "Move an Object identified by `{orderId}` to the recycling bin.",
+                "operationId": "delete-/crm/v3/objects/orders/{orderId}",
+                "parameters": [
+                    {
+                        "name": "orderId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the order to delete."
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.orders.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.orders.write"
+                        ]
+                    }
+                ]
+            },
+            "patch": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Update an order by ID",
+                "description": "Perform a partial update of an Object identified by `{orderId}`. `{orderId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.",
+                "operationId": "patch-/crm/v3/objects/orders/{orderId}",
+                "parameters": [
+                    {
+                        "name": "orderId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the order to update."
+                    },
+                    {
+                        "name": "idProperty",
+                        "in": "query",
+                        "description": "The name of a property whose values are unique for this object type",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SimplePublicObjectInput"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.orders.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.orders.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/batch/archive": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Archive a batch of orders by ID",
+                "operationId": "post-/crm/v3/objects/orders/batch/archive",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputSimplePublicObjectId"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.orders.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.orders.write"
+                        ]
+                    }
+                ],
+                "description": "Archives the specified orders by ID, returning no content on success."
+            }
+        },
+        "/batch/create": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Create a batch of orders",
+                "operationId": "post-/crm/v3/objects/orders/batch/create",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputSimplePublicObjectInputForCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.orders.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.orders.write"
+                        ]
+                    }
+                ],
+                "description": "Returns a batch of newly created order objects, including their assigned IDs and properties. Partial success indicated by 207."
+            }
+        },
+        "/batch/update": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Update a batch of orders",
+                "operationId": "post-/crm/v3/objects/orders/batch/update",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputSimplePublicObjectBatchInput"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.orders.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.orders.write"
+                        ]
+                    }
+                ],
+                "description": "Returns the updated order objects after applying the specified property changes to each record in the batch."
+            }
+        },
+        "/": {
+            "get": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "List all orders",
+                "description": "Read a page of orders. Control what is returned via the `properties` query param.",
+                "operationId": "get-/crm/v3/objects/orders",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of results to display per page",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 10
+                        }
+                    },
+                    {
+                        "name": "after",
+                        "in": "query",
+                        "description": "The paging cursor token of the last successfully read resource will be returned as the `paging.next.after` JSON property of a paged response containing more results",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "properties",
+                        "in": "query",
+                        "description": "A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "propertiesWithHistory",
+                        "in": "query",
+                        "description": "A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored. Usage of this parameter will reduce the maximum number of objects that can be read by a single request",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "associations",
+                        "in": "query",
+                        "description": "A comma separated list of object types to retrieve associated IDs for. If any of the specified associations do not exist, they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "archived",
+                        "in": "query",
+                        "description": "Whether to return only results that have been archived",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponseSimplePublicObjectWithAssociationsForwardPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.orders.read"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.orders.read"
+                        ]
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Create a new order",
+                "description": "Create a order with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard orders is provided.",
+                "operationId": "post-/crm/v3/objects/orders",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SimplePublicObjectInputForCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.orders.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.orders.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/batch/upsert": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Upsert orders by property values",
+                "operationId": "post-/crm/v3/objects/orders/batch/upsert",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputSimplePublicObjectBatchInputUpsert"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicUpsertObject"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicUpsertObjectWithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.orders.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.orders.write"
+                        ]
+                    }
+                ],
+                "description": "Returns the created or updated order objects matched by unique property values, with their current state after the operation."
+            }
+        },
+        "/search": {
+            "post": {
+                "tags": [
+                    "Search"
+                ],
+                "operationId": "post-/crm/v3/objects/orders/search",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PublicObjectSearchRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponseWithTotalSimplePublicObjectForwardPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.orders.read"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.orders.read"
+                        ]
+                    }
+                ],
+                "x-hubspot-rate-limit-exemptions": [
+                    "ten-secondly"
+                ],
+                "description": "Returns a paginated list of order objects matching the specified search criteria, filters, and sorting options.",
+                "summary": "Search orders"
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "StandardError": {
+                "required": [
+                    "category",
+                    "context",
+                    "errors",
+                    "links",
+                    "message",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "object",
+                        "properties": {},
+                        "description": "Optional sub-category providing additional error classification."
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Contextual metadata map with string array values for the error."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant links associated with the error response."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier for the error instance."
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "High-level category classifying the type of error."
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "Human-readable message describing the error."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ErrorDetail"
+                        },
+                        "description": "List of detailed error objects providing granular error info."
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "HTTP status code or status string associated with the error."
+                    }
+                },
+                "description": "Standard error response structure returned by the Orders API."
+            },
+            "CollectionResponseAssociatedId": {
+                "required": [
+                    "results"
+                ],
+                "type": "object",
+                "properties": {
+                    "paging": {
+                        "$ref": "#/components/schemas/Paging",
+                        "description": "Paging metadata for navigating the result set."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AssociatedId"
+                        },
+                        "description": "Array of associated object IDs returned in the response."
+                    }
+                },
+                "description": "Paginated collection of associated object IDs."
+            },
+            "PublicAssociationsForObject": {
+                "required": [
+                    "to",
+                    "types"
+                ],
+                "type": "object",
+                "properties": {
+                    "types": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AssociationSpec"
+                        },
+                        "description": "List of association type specifications for the relationship."
+                    },
+                    "to": {
+                        "$ref": "#/components/schemas/PublicObjectId",
+                        "description": "The target object to associate with."
+                    }
+                },
+                "description": "Defines association targets and their types for a given object."
+            },
+            "BatchResponseSimplePublicObject": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the batch operation completed."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the batch operation started processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant links associated with the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObject"
+                        },
+                        "description": "Array of order objects returned by the batch operation."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch request."
+                    }
+                },
+                "description": "Batch operation response containing results and processing status."
+            },
+            "FilterGroup": {
+                "required": [
+                    "filters"
+                ],
+                "type": "object",
+                "properties": {
+                    "filters": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Filter"
+                        },
+                        "description": "Array of filter conditions within this group."
+                    }
+                },
+                "description": "A logical grouping of filters applied together when searching orders."
+            },
+            "ErrorDetail": {
+                "required": [
+                    "message"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "string",
+                        "description": "A specific category that contains more specific detail about the error"
+                    },
+                    "code": {
+                        "type": "string",
+                        "description": "The status code associated with the error detail"
+                    },
+                    "in": {
+                        "type": "string",
+                        "description": "The name of the field or parameter in which the error was found"
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Context about the error condition",
+                        "example": {
+                            "missingScopes": [
+                                "scope1",
+                                "scope2"
+                            ]
+                        }
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "A human readable message describing the error along with remediation steps where appropriate"
+                    }
+                },
+                "description": "Detailed information about a specific error encountered during a request."
+            },
+            "ForwardPaging": {
+                "type": "object",
+                "properties": {
+                    "next": {
+                        "$ref": "#/components/schemas/NextPage",
+                        "description": "Cursor and link to retrieve the next page of results."
+                    }
+                },
+                "description": "Pagination metadata for forward-only cursor-based navigation."
+            },
+            "SimplePublicObjectId": {
+                "required": [
+                    "id"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the object."
+                    }
+                },
+                "description": "A minimal object representation containing only a unique identifier."
+            },
+            "BatchResponseSimplePublicUpsertObjectWithErrors": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of errors encountered during the batch operation."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation began processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant hyperlinks associated with the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicUpsertObject"
+                        },
+                        "description": "Array of successfully upserted order objects."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "Array of errors encountered for individual records in the batch."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch upsert request."
+                    }
+                },
+                "description": "Batch upsert response including results, errors, and processing status details."
+            },
+            "BatchReadInputSimplePublicObjectId": {
+                "required": [
+                    "inputs",
+                    "properties",
+                    "propertiesWithHistory"
+                ],
+                "type": "object",
+                "properties": {
+                    "propertiesWithHistory": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of properties for which historical values should be returned."
+                    },
+                    "idProperty": {
+                        "type": "string",
+                        "description": "The property to use as the unique identifier for lookup."
+                    },
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectId"
+                        },
+                        "description": "List of object IDs to retrieve in the batch read."
+                    },
+                    "properties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of property names to include in the response."
+                    }
+                },
+                "description": "Input payload for batch reading orders by ID, including requested properties."
+            },
+            "BatchResponseSimplePublicUpsertObject": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the batch operation completed."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the batch operation started."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant links associated with the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicUpsertObject"
+                        },
+                        "description": "List of upserted objects returned by the batch operation."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch operation."
+                    }
+                },
+                "description": "Response object containing the status, timing, and results of a batch upsert operation."
+            },
+            "BatchInputSimplePublicObjectId": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectId"
+                        },
+                        "description": "List of object IDs to process in the batch operation."
+                    }
+                },
+                "description": "Input schema containing a list of object IDs for a batch operation."
+            },
+            "ValueWithTimestamp": {
+                "required": [
+                    "sourceType",
+                    "timestamp",
+                    "value"
+                ],
+                "type": "object",
+                "properties": {
+                    "sourceId": {
+                        "type": "string",
+                        "description": "Identifier of the source that set this value."
+                    },
+                    "sourceType": {
+                        "type": "string",
+                        "description": "Type of source that originated this value."
+                    },
+                    "sourceLabel": {
+                        "type": "string",
+                        "description": "Human-readable label describing the value's source."
+                    },
+                    "updatedByUserId": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "ID of the user who last updated this value."
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "The property value as a string."
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the value was last updated."
+                    }
+                },
+                "description": "A property value paired with its source metadata and the timestamp of the last update."
+            },
+            "BatchInputSimplePublicObjectBatchInputUpsert": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectBatchInputUpsert"
+                        },
+                        "description": "Array of order objects to upsert in batch."
+                    }
+                },
+                "description": "Input schema containing a list of objects to create or update in a batch upsert operation."
+            },
+            "CollectionResponseWithTotalSimplePublicObjectForwardPaging": {
+                "required": [
+                    "results",
+                    "total"
+                ],
+                "type": "object",
+                "properties": {
+                    "total": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of orders matching the request."
+                    },
+                    "paging": {
+                        "$ref": "#/components/schemas/ForwardPaging",
+                        "description": "Forward paging cursor for retrieving the next result set."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObject"
+                        },
+                        "description": "Array of order objects returned in the current page."
+                    }
+                },
+                "description": "A paginated collection of order objects with a total count and forward paging cursor."
+            },
+            "SimplePublicObject": {
+                "required": [
+                    "createdAt",
+                    "id",
+                    "properties",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the order was created."
+                    },
+                    "archived": {
+                        "type": "boolean",
+                        "example": false,
+                        "description": "Indicates whether the order is archived."
+                    },
+                    "archivedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the order was archived."
+                    },
+                    "propertiesWithHistory": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/ValueWithTimestamp"
+                            }
+                        },
+                        "description": "Map of order properties including their historical values with timestamps."
+                    },
+                    "id": {
+                        "type": "string",
+                        "example": "512",
+                        "description": "Unique identifier of the order object."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        },
+                        "example": {
+                            "property_date": "1572480000000",
+                            "property_radio": "option_1",
+                            "property_number": "17",
+                            "property_string": "value",
+                            "property_checkbox": "false",
+                            "property_dropdown": "choice_b",
+                            "property_multiple_checkboxes": "chocolate;strawberry"
+                        },
+                        "description": "Map of order property names to their current values."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the order was last updated."
+                    }
+                },
+                "example": {
+                    "id": "512",
+                    "properties": {
+                        "createdate": "2019-10-30T03:30:17.883Z",
+                        "hs_currency_code": "USD",
+                        "hs_external_created_date": "1709814663",
+                        "hs_lastmodifieddate": "2019-12-07T16:50:06.678Z",
+                        "hs_order_name": "Order Name",
+                        "hs_pipeline": "Pipeline ID",
+                        "hs_pipeline_stage": "Pipeline Stage ID",
+                        "hs_source_store": "Store Name",
+                        "hs_total_price": "100.00"
+                    },
+                    "createdAt": "2019-10-30T03:30:17.883Z",
+                    "updatedAt": "2019-12-07T16:50:06.678Z",
+                    "archived": false
+                },
+                "description": "Represents a single order object with its properties, metadata, and optional history."
+            },
+            "PublicObjectId": {
+                "required": [
+                    "id"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the public object."
+                    }
+                },
+                "description": "Represents a public object identifier containing a unique ID string."
+            },
+            "Paging": {
+                "type": "object",
+                "properties": {
+                    "next": {
+                        "$ref": "#/components/schemas/NextPage",
+                        "description": "Cursor information for retrieving the next page."
+                    },
+                    "prev": {
+                        "$ref": "#/components/schemas/PreviousPage",
+                        "description": "Cursor information for retrieving the previous page."
+                    }
+                },
+                "description": "Pagination object containing cursors for navigating to the next or previous result page."
+            },
+            "PublicObjectSearchRequest": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Full-text search query string to match against order records."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Maximum number of results to return in the response."
+                    },
+                    "after": {
+                        "type": "string",
+                        "description": "Cursor token for retrieving the next page of results."
+                    },
+                    "sorts": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of property names to sort results by."
+                    },
+                    "properties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of property names to include in the response."
+                    },
+                    "filterGroups": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/FilterGroup"
+                        },
+                        "description": "Groups of filters to apply when narrowing search results."
+                    }
+                },
+                "description": "Request payload for searching orders with filters, sorting, and pagination options."
+            },
+            "Error": {
+                "required": [
+                    "category",
+                    "correlationId",
+                    "message"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "string",
+                        "description": "A specific category that contains more specific detail about the error"
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Context about the error condition",
+                        "example": {
+                            "missingScopes": [
+                                "scope1",
+                                "scope2"
+                            ],
+                            "invalidPropertyName": [
+                                "propertyValue"
+                            ]
+                        }
+                    },
+                    "correlationId": {
+                        "type": "string",
+                        "description": "A unique identifier for the request. Include this value with any error reports or support tickets",
+                        "format": "uuid",
+                        "example": "aeb5f871-7f07-4993-9211-075dc63e7cbf"
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "A map of link names to associated URIs containing documentation about the error or recommended remediation steps",
+                        "example": {
+                            "knowledge-base": "https://www.hubspot.com/products/service/knowledge-base"
+                        }
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "A human readable message describing the error along with remediation steps where appropriate",
+                        "example": "Invalid input (details will vary based on the error)"
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "The error category",
+                        "example": "VALIDATION_ERROR"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "description": "further information about the error",
+                        "items": {
+                            "$ref": "#/components/schemas/ErrorDetail"
+                        }
+                    }
+                },
+                "example": {
+                    "message": "Invalid input (details will vary based on the error)",
+                    "correlationId": "aeb5f871-7f07-4993-9211-075dc63e7cbf",
+                    "category": "VALIDATION_ERROR",
+                    "links": {
+                        "knowledge-base": "https://www.hubspot.com/products/service/knowledge-base"
+                    }
+                },
+                "description": "Represents an API error response, including category, message, correlation ID, and contextual details."
+            },
+            "SimplePublicObjectBatchInputUpsert": {
+                "required": [
+                    "id",
+                    "properties"
+                ],
+                "type": "object",
+                "properties": {
+                    "idProperty": {
+                        "type": "string",
+                        "description": "The property name used as the unique identifier for the upsert."
+                    },
+                    "objectWriteTraceId": {
+                        "type": "string",
+                        "description": "Trace identifier for tracking the write operation."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the order to upsert."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Key-value map of order property names and their values."
+                    }
+                },
+                "description": "Input object for upserting an order, containing an identifier and a map of property values."
+            },
+            "BatchResponseSimplePublicObjectWithErrors": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the batch operation completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of errors encountered during the batch operation."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the batch operation started processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant link names to associated URIs for the response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObject"
+                        },
+                        "description": "List of successfully processed order objects from the batch."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "List of errors encountered for individual records in the batch."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch operation."
+                    }
+                },
+                "description": "Batch operation response containing results, status, timestamps, and any errors encountered."
+            },
+            "SimplePublicObjectInput": {
+                "required": [
+                    "properties"
+                ],
+                "type": "object",
+                "properties": {
+                    "objectWriteTraceId": {
+                        "type": "string",
+                        "description": "Trace identifier for tracking the write operation."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "example": {
+                            "property_date": "1572480000000",
+                            "property_radio": "option_1",
+                            "property_number": "17",
+                            "property_string": "value",
+                            "property_checkbox": "false",
+                            "property_dropdown": "choice_b",
+                            "property_multiple_checkboxes": "chocolate;strawberry"
+                        },
+                        "description": "Key-value map of order property names and their string values."
+                    }
+                },
+                "example": {
+                    "properties": {
+                        "hs_pipeline": "Pipeline ID",
+                        "hs_order_name": "Order Name",
+                        "hs_total_price": "100.00",
+                        "hs_source_store": "Store Name",
+                        "hs_currency_code": "USD",
+                        "hs_pipeline_stage": "Pipeline Stage ID",
+                        "hs_external_created_date": "1709814663"
+                    },
+                    "associations": [
+                        {
+                            "to": {
+                                "id": "1"
+                            },
+                            "types": [
+                                {
+                                    "associationCategory": "HUBSPOT_DEFINED",
+                                    "associationTypeId": 2
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "description": "Input schema for creating or updating an order object with properties and associations."
+            },
+            "CollectionResponseSimplePublicObjectWithAssociationsForwardPaging": {
+                "required": [
+                    "results"
+                ],
+                "type": "object",
+                "properties": {
+                    "paging": {
+                        "$ref": "#/components/schemas/ForwardPaging",
+                        "description": "Forward paging cursor for retrieving the next page of results."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectWithAssociations"
+                        },
+                        "description": "Array of order objects returned in the current page."
+                    }
+                },
+                "description": "Paginated collection of order objects including their associated records."
+            },
+            "AssociationSpec": {
+                "required": [
+                    "associationCategory",
+                    "associationTypeId"
+                ],
+                "type": "object",
+                "properties": {
+                    "associationCategory": {
+                        "type": "string",
+                        "enum": [
+                            "HUBSPOT_DEFINED",
+                            "USER_DEFINED",
+                            "INTEGRATOR_DEFINED"
+                        ],
+                        "description": "Category of the association: HUBSPOT_DEFINED, USER_DEFINED, or INTEGRATOR_DEFINED."
+                    },
+                    "associationTypeId": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Numeric identifier for the specific association type."
+                    }
+                },
+                "description": "Defines the category and type of an association between two objects."
+            },
+            "SimplePublicObjectWithAssociations": {
+                "required": [
+                    "createdAt",
+                    "id",
+                    "properties",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "associations": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/CollectionResponseAssociatedId"
+                        },
+                        "description": "Map of associated object collections keyed by association type."
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the order record was created."
+                    },
+                    "archived": {
+                        "type": "boolean",
+                        "description": "Indicates whether the order record is archived."
+                    },
+                    "archivedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the order record was archived."
+                    },
+                    "propertiesWithHistory": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/ValueWithTimestamp"
+                            }
+                        },
+                        "description": "Map of property names to their historical values with timestamps."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the order record."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        },
+                        "description": "Key-value map of the order's current property names and values."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the order record was last updated."
+                    }
+                },
+                "example": {
+                    "properties": {
+                        "createdate": "2019-10-30T03:30:17.883Z",
+                        "hs_currency_code": "USD",
+                        "hs_external_created_date": "1709814663",
+                        "hs_lastmodifieddate": "2019-12-07T16:50:06.678Z",
+                        "hs_order_name": "Order Name",
+                        "hs_pipeline": "Pipeline ID",
+                        "hs_pipeline_stage": "Pipeline Stage ID",
+                        "hs_source_store": "Store Name",
+                        "hs_total_price": "100.00"
+                    }
+                },
+                "description": "An order object including its properties, metadata, and associated records."
+            },
+            "Filter": {
+                "required": [
+                    "operator",
+                    "propertyName"
+                ],
+                "type": "object",
+                "properties": {
+                    "highValue": {
+                        "type": "string",
+                        "description": "Upper bound value used with the BETWEEN operator."
+                    },
+                    "propertyName": {
+                        "type": "string",
+                        "description": "The name of the property to filter by."
+                    },
+                    "values": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "A list of values to match against the filter property."
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "The single value to match against the filter property."
+                    },
+                    "operator": {
+                        "type": "string",
+                        "description": "The comparison operator used to evaluate the filter condition.",
+                        "enum": [
+                            "EQ",
+                            "NEQ",
+                            "LT",
+                            "LTE",
+                            "GT",
+                            "GTE",
+                            "BETWEEN",
+                            "IN",
+                            "NOT_IN",
+                            "HAS_PROPERTY",
+                            "NOT_HAS_PROPERTY",
+                            "CONTAINS_TOKEN",
+                            "NOT_CONTAINS_TOKEN"
+                        ]
+                    }
+                },
+                "description": "Defines a filter condition using a property, operator, and comparison value."
+            },
+            "BatchInputSimplePublicObjectBatchInput": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectBatchInput"
+                        },
+                        "description": "An array of objects to be updated in the batch operation."
+                    }
+                },
+                "description": "A batch input wrapper containing an array of objects to update."
+            },
+            "BatchInputSimplePublicObjectInputForCreate": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectInputForCreate"
+                        },
+                        "description": "An array of objects to be created in the batch operation."
+                    }
+                },
+                "description": "A batch input wrapper containing an array of objects to create."
+            },
+            "PreviousPage": {
+                "required": [
+                    "before"
+                ],
+                "type": "object",
+                "properties": {
+                    "before": {
+                        "type": "string",
+                        "description": "The cursor token representing the start of the previous page."
+                    },
+                    "link": {
+                        "type": "string",
+                        "description": "The URL link to retrieve the previous page of results."
+                    }
+                },
+                "description": "Pagination cursor details for navigating to the previous page of results."
+            },
+            "SimplePublicUpsertObject": {
+                "required": [
+                    "createdAt",
+                    "id",
+                    "new",
+                    "properties",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The timestamp when the object was created."
+                    },
+                    "archived": {
+                        "type": "boolean",
+                        "description": "Indicates whether the object is archived."
+                    },
+                    "archivedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The timestamp when the object was archived."
+                    },
+                    "new": {
+                        "type": "boolean",
+                        "description": "Indicates whether the object was newly created by the upsert."
+                    },
+                    "propertiesWithHistory": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/ValueWithTimestamp"
+                            }
+                        },
+                        "description": "A map of property names to their historical values with timestamps."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the object."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "A map of property names to their current string values."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The timestamp when the object was last updated."
+                    }
+                },
+                "description": "Represents an order object returned after an upsert operation, including metadata and property values."
+            },
+            "SimplePublicObjectBatchInput": {
+                "required": [
+                    "id",
+                    "properties"
+                ],
+                "type": "object",
+                "properties": {
+                    "idProperty": {
+                        "type": "string",
+                        "example": "my_unique_property_name",
+                        "description": "The property name used as the unique identifier for the order."
+                    },
+                    "objectWriteTraceId": {
+                        "type": "string",
+                        "description": "Trace ID for tracking the write operation."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the order to update."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Key-value pairs of order properties to update."
+                    }
+                },
+                "example": {
+                    "id": "1",
+                    "properties": {
+                        "hs_pipeline": "Pipeline ID",
+                        "hs_order_name": "Order Name",
+                        "hs_total_price": "100.00",
+                        "hs_source_store": "Store Name",
+                        "hs_currency_code": "USD",
+                        "hs_pipeline_stage": "Pipeline Stage ID",
+                        "hs_external_created_date": "1709814663"
+                    }
+                },
+                "description": "Input schema for updating a single order in a batch operation."
+            },
+            "AssociatedId": {
+                "required": [
+                    "id",
+                    "type"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the associated object."
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "The type of association between the objects."
+                    }
+                },
+                "description": "Represents an associated object's ID and association type."
+            },
+            "NextPage": {
+                "required": [
+                    "after"
+                ],
+                "type": "object",
+                "properties": {
+                    "link": {
+                        "type": "string",
+                        "example": "?after=NTI1Cg%3D%3D",
+                        "description": "The URL query string to fetch the next page of results."
+                    },
+                    "after": {
+                        "type": "string",
+                        "example": "NTI1Cg%3D%3D",
+                        "description": "The cursor token used to retrieve the next page of results."
+                    }
+                },
+                "example": {
+                    "after": "NTI1Cg%3D%3D",
+                    "link": "?after=NTI1Cg%3D%3D"
+                },
+                "description": "Pagination cursor details for retrieving the next page of results."
+            },
+            "SimplePublicObjectInputForCreate": {
+                "required": [
+                    "associations",
+                    "properties"
+                ],
+                "type": "object",
+                "properties": {
+                    "associations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicAssociationsForObject"
+                        },
+                        "description": "List of associated objects to link to the new order."
+                    },
+                    "objectWriteTraceId": {
+                        "type": "string",
+                        "description": "Trace ID for tracking the write operation."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Key-value pairs of order properties to set on creation."
+                    }
+                },
+                "example": {
+                    "properties": {
+                        "hs_pipeline": "Pipeline ID",
+                        "hs_order_name": "Order Name",
+                        "hs_total_price": "100.00",
+                        "hs_source_store": "Store Name",
+                        "hs_currency_code": "USD",
+                        "hs_pipeline_stage": "Pipeline Stage ID",
+                        "hs_external_created_date": "1709814663"
+                    },
+                    "associations": [
+                        {
+                            "to": {
+                                "id": "1"
+                            },
+                            "types": [
+                                {
+                                    "associationCategory": "HUBSPOT_DEFINED",
+                                    "associationTypeId": 2
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "description": "Input schema for creating a new order with properties and associations."
+            }
+        },
+        "responses": {
+            "Error": {
+                "description": "An error occurred.",
+                "content": {
+                    "*/*": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "oauth2_legacy": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "https://app.hubspot.com/oauth/authorize",
+                        "tokenUrl": "https://api.hubapi.com/oauth/v1/token",
+                        "scopes": {
+                            "crm.objects.goals.read": "Read goals",
+                            "tickets": "Read and write tickets",
+                            "crm.objects.custom.read": "View custom object records",
+                            "e-commerce": "e-commerce",
+                            "crm.objects.custom.write": "Change custom object records",
+                            "media_bridge.read": "Read media and media events"
+                        }
+                    }
+                }
+            },
+            "oauth2": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "https://app.hubspot.com/oauth/authorize",
+                        "tokenUrl": "https://api.hubapi.com/oauth/v1/token",
+                        "scopes": {
+                            "crm.objects.companies.write": " ",
+                            "crm.objects.contacts.write": " ",
+                            "crm.objects.users.write": "Write User CRM objects",
+                            "crm.objects.commercepayments.read": "Read the COMMERCE_PAYMENT object.",
+                            "crm.objects.leads.write": "Modify lead objects",
+                            "crm.objects.subscriptions.read": "Read Commerce Subscriptions",
+                            "crm.objects.carts.read": "Read carts",
+                            "crm.objects.orders.write": "Write orders",
+                            "crm.objects.quotes.read": "Quotes",
+                            "crm.objects.services.read": "Read services",
+                            "crm.objects.orders.read": "Read Orders",
+                            "crm.objects.contacts.read": " ",
+                            "crm.objects.listings.read": "Read listings",
+                            "crm.objects.carts.write": "Write cart",
+                            "crm.objects.courses.write": "Write courses",
+                            "crm.objects.quotes.write": "Quotes",
+                            "crm.objects.users.read": "Read User CRM objects",
+                            "crm.objects.companies.read": " ",
+                            "crm.objects.appointments.read": "Read appointments",
+                            "crm.objects.partner-clients.write": "Modify Partner Client CRM objects",
+                            "crm.objects.leads.read": "Read lead objects",
+                            "crm.objects.appointments.write": "Write appointments",
+                            "crm.objects.services.write": "Write services",
+                            "crm.objects.line_items.read": "Line Items",
+                            "crm.objects.courses.read": "Read courses",
+                            "crm.objects.deals.read": " ",
+                            "crm.objects.invoices.read": "Read invoices objects",
+                            "crm.objects.partner-clients.read": "View Partner Client CRM objects",
+                            "crm.objects.deals.write": " ",
+                            "crm.objects.line_items.write": "Line Items",
+                            "crm.objects.listings.write": "Write listings"
+                        }
+                    }
+                }
+            },
+            "private_apps_legacy": {
+                "type": "apiKey",
+                "name": "private-app-legacy",
+                "in": "header",
+                "x-ballerina-name": "privateAppLegacy"
+            },
+            "private_apps": {
+                "type": "apiKey",
+                "name": "private-app",
+                "in": "header",
+                "x-ballerina-name": "privateApp"
+            }
+        }
+    }
+}

--- a/docs/spec/flattened_openapi.json
+++ b/docs/spec/flattened_openapi.json
@@ -1,0 +1,1654 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "Orders",
+    "description" : "",
+    "version" : "v3",
+    "x-hubspot-product-tier-requirements" : {
+      "marketing" : "FREE",
+      "sales" : "FREE",
+      "service" : "FREE",
+      "cms" : "FREE"
+    },
+    "x-hubspot-documentation-banner" : "NONE",
+    "x-hubspot-api-use-case" : "When a buyer adds a set of products to their cart and makes a purchase, store it as an individual order. You can then update the order with tracking information once the shipping label has been printed.",
+    "x-hubspot-related-documentation" : [ {
+      "name" : "Orders overview",
+      "url" : "https://developers.hubspot.com/beta-docs/guides/api/crm/commerce/orders"
+    } ],
+    "x-hubspot-introduction" : "Use the orders API to create and manage data related to ecommerce purchases in HubSpot. This can be especially useful for keeping HubSpot data synced with external ecommerce platforms, such as Shopify and NetSuite."
+  },
+  "servers" : [ {
+    "url" : "https://api.hubapi.com/crm/v3/objects/orders"
+  } ],
+  "tags" : [ {
+    "name" : "Batch"
+  }, {
+    "name" : "Basic"
+  }, {
+    "name" : "Search"
+  } ],
+  "paths" : {
+    "/batch/read" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Read a batch of orders by internal ID, or unique property values",
+        "operationId" : "post-/crm/v3/objects/orders/batch/read",
+        "parameters" : [ {
+          "name" : "archived",
+          "in" : "query",
+          "description" : "Whether to return only results that have been archived",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchReadInputSimplePublicObjectId"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObject"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.orders.read" ]
+        }, {
+          "private_apps" : [ "crm.objects.orders.read" ]
+        } ]
+      }
+    },
+    "/{orderId}" : {
+      "get" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Read",
+        "description" : "Read an Object identified by `{orderId}`. `{orderId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.",
+        "operationId" : "get-/crm/v3/objects/orders/{orderId}",
+        "parameters" : [ {
+          "name" : "orderId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "properties",
+          "in" : "query",
+          "description" : "A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "propertiesWithHistory",
+          "in" : "query",
+          "description" : "A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "associations",
+          "in" : "query",
+          "description" : "A comma separated list of object types to retrieve associated IDs for. If any of the specified associations do not exist, they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "archived",
+          "in" : "query",
+          "description" : "Whether to return only results that have been archived",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        }, {
+          "name" : "idProperty",
+          "in" : "query",
+          "description" : "The name of a property whose values are unique for this object type",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimplePublicObjectWithAssociations"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.orders.read" ]
+        }, {
+          "private_apps" : [ "crm.objects.orders.read" ]
+        } ]
+      },
+      "delete" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Archive",
+        "description" : "Move an Object identified by `{orderId}` to the recycling bin.",
+        "operationId" : "delete-/crm/v3/objects/orders/{orderId}",
+        "parameters" : [ {
+          "name" : "orderId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.orders.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.orders.write" ]
+        } ]
+      },
+      "patch" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Update",
+        "description" : "Perform a partial update of an Object identified by `{orderId}`. `{orderId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will be ignored. Properties values can be cleared by passing an empty string.",
+        "operationId" : "patch-/crm/v3/objects/orders/{orderId}",
+        "parameters" : [ {
+          "name" : "orderId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "idProperty",
+          "in" : "query",
+          "description" : "The name of a property whose values are unique for this object type",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SimplePublicObjectInput"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimplePublicObject"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.orders.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.orders.write" ]
+        } ]
+      }
+    },
+    "/batch/archive" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Archive a batch of orders by ID",
+        "operationId" : "post-/crm/v3/objects/orders/batch/archive",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputSimplePublicObjectId"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.orders.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.orders.write" ]
+        } ]
+      }
+    },
+    "/batch/create" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Create a batch of orders",
+        "operationId" : "post-/crm/v3/objects/orders/batch/create",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputSimplePublicObjectInputForCreate"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObject"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.orders.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.orders.write" ]
+        } ]
+      }
+    },
+    "/batch/update" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Update a batch of orders",
+        "operationId" : "post-/crm/v3/objects/orders/batch/update",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputSimplePublicObjectBatchInput"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObject"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.orders.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.orders.write" ]
+        } ]
+      }
+    },
+    "/" : {
+      "get" : {
+        "tags" : [ "Basic" ],
+        "summary" : "List",
+        "description" : "Read a page of orders. Control what is returned via the `properties` query param.",
+        "operationId" : "get-/crm/v3/objects/orders",
+        "parameters" : [ {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The maximum number of results to display per page",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "after",
+          "in" : "query",
+          "description" : "The paging cursor token of the last successfully read resource will be returned as the `paging.next.after` JSON property of a paged response containing more results",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "properties",
+          "in" : "query",
+          "description" : "A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "propertiesWithHistory",
+          "in" : "query",
+          "description" : "A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored. Usage of this parameter will reduce the maximum number of objects that can be read by a single request",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "associations",
+          "in" : "query",
+          "description" : "A comma separated list of object types to retrieve associated IDs for. If any of the specified associations do not exist, they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "archived",
+          "in" : "query",
+          "description" : "Whether to return only results that have been archived",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponseSimplePublicObjectWithAssociationsForwardPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.orders.read" ]
+        }, {
+          "private_apps" : [ "crm.objects.orders.read" ]
+        } ]
+      },
+      "post" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Create",
+        "description" : "Create a order with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard orders is provided.",
+        "operationId" : "post-/crm/v3/objects/orders",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SimplePublicObjectInputForCreate"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimplePublicObject"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.orders.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.orders.write" ]
+        } ]
+      }
+    },
+    "/batch/upsert" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Create or update a batch of orders by unique property values",
+        "operationId" : "post-/crm/v3/objects/orders/batch/upsert",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputSimplePublicObjectBatchInputUpsert"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicUpsertObject"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicUpsertObjectWithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.orders.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.orders.write" ]
+        } ]
+      }
+    },
+    "/search" : {
+      "post" : {
+        "tags" : [ "Search" ],
+        "operationId" : "post-/crm/v3/objects/orders/search",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PublicObjectSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponseWithTotalSimplePublicObjectForwardPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.orders.read" ]
+        }, {
+          "private_apps" : [ "crm.objects.orders.read" ]
+        } ],
+        "x-hubspot-rate-limit-exemptions" : [ "ten-secondly" ]
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "StandardError" : {
+        "required" : [ "category", "context", "errors", "links", "message", "status" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "object",
+            "properties" : { }
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "category" : {
+            "type" : "string"
+          },
+          "message" : {
+            "type" : "string"
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ErrorDetail"
+            }
+          },
+          "status" : {
+            "type" : "string"
+          }
+        }
+      },
+      "CollectionResponseAssociatedId" : {
+        "required" : [ "results" ],
+        "type" : "object",
+        "properties" : {
+          "paging" : {
+            "$ref" : "#/components/schemas/Paging"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AssociatedId"
+            }
+          }
+        }
+      },
+      "PublicAssociationsForObject" : {
+        "required" : [ "to", "types" ],
+        "type" : "object",
+        "properties" : {
+          "types" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AssociationSpec"
+            }
+          },
+          "to" : {
+            "$ref" : "#/components/schemas/PublicObjectId"
+          }
+        }
+      },
+      "BatchResponseSimplePublicObject" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObject"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "FilterGroup" : {
+        "required" : [ "filters" ],
+        "type" : "object",
+        "properties" : {
+          "filters" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Filter"
+            }
+          }
+        }
+      },
+      "ErrorDetail" : {
+        "required" : [ "message" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "string",
+            "description" : "A specific category that contains more specific detail about the error"
+          },
+          "code" : {
+            "type" : "string",
+            "description" : "The status code associated with the error detail"
+          },
+          "in" : {
+            "type" : "string",
+            "description" : "The name of the field or parameter in which the error was found"
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "description" : "Context about the error condition",
+            "example" : {
+              "missingScopes" : [ "scope1", "scope2" ]
+            }
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "A human readable message describing the error along with remediation steps where appropriate"
+          }
+        }
+      },
+      "ForwardPaging" : {
+        "type" : "object",
+        "properties" : {
+          "next" : {
+            "$ref" : "#/components/schemas/NextPage"
+          }
+        }
+      },
+      "SimplePublicObjectId" : {
+        "required" : [ "id" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "BatchResponseSimplePublicUpsertObjectWithErrors" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicUpsertObject"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "BatchReadInputSimplePublicObjectId" : {
+        "required" : [ "inputs", "properties", "propertiesWithHistory" ],
+        "type" : "object",
+        "properties" : {
+          "propertiesWithHistory" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "idProperty" : {
+            "type" : "string"
+          },
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectId"
+            }
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "BatchResponseSimplePublicUpsertObject" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicUpsertObject"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "BatchInputSimplePublicObjectId" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectId"
+            }
+          }
+        }
+      },
+      "ValueWithTimestamp" : {
+        "required" : [ "sourceType", "timestamp", "value" ],
+        "type" : "object",
+        "properties" : {
+          "sourceId" : {
+            "type" : "string"
+          },
+          "sourceType" : {
+            "type" : "string"
+          },
+          "sourceLabel" : {
+            "type" : "string"
+          },
+          "updatedByUserId" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "value" : {
+            "type" : "string"
+          },
+          "timestamp" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }
+      },
+      "BatchInputSimplePublicObjectBatchInputUpsert" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectBatchInputUpsert"
+            }
+          }
+        }
+      },
+      "CollectionResponseWithTotalSimplePublicObjectForwardPaging" : {
+        "required" : [ "results", "total" ],
+        "type" : "object",
+        "properties" : {
+          "total" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "paging" : {
+            "$ref" : "#/components/schemas/ForwardPaging"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObject"
+            }
+          }
+        }
+      },
+      "SimplePublicObject" : {
+        "required" : [ "createdAt", "id", "properties", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "archived" : {
+            "type" : "boolean",
+            "example" : false
+          },
+          "archivedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "propertiesWithHistory" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/ValueWithTimestamp"
+              }
+            }
+          },
+          "id" : {
+            "type" : "string",
+            "example" : "512"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string",
+              "nullable" : true
+            },
+            "example" : {
+              "property_date" : "1572480000000",
+              "property_radio" : "option_1",
+              "property_number" : "17",
+              "property_string" : "value",
+              "property_checkbox" : "false",
+              "property_dropdown" : "choice_b",
+              "property_multiple_checkboxes" : "chocolate;strawberry"
+            }
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        },
+        "example" : {
+          "id" : "512",
+          "properties" : {
+            "createdate" : "2019-10-30T03:30:17.883Z",
+            "hs_currency_code" : "USD",
+            "hs_external_created_date" : "1709814663",
+            "hs_lastmodifieddate" : "2019-12-07T16:50:06.678Z",
+            "hs_order_name" : "Order Name",
+            "hs_pipeline" : "Pipeline ID",
+            "hs_pipeline_stage" : "Pipeline Stage ID",
+            "hs_source_store" : "Store Name",
+            "hs_total_price" : "100.00"
+          },
+          "createdAt" : "2019-10-30T03:30:17.883Z",
+          "updatedAt" : "2019-12-07T16:50:06.678Z",
+          "archived" : false
+        }
+      },
+      "PublicObjectId" : {
+        "required" : [ "id" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "Paging" : {
+        "type" : "object",
+        "properties" : {
+          "next" : {
+            "$ref" : "#/components/schemas/NextPage"
+          },
+          "prev" : {
+            "$ref" : "#/components/schemas/PreviousPage"
+          }
+        }
+      },
+      "PublicObjectSearchRequest" : {
+        "type" : "object",
+        "properties" : {
+          "query" : {
+            "type" : "string"
+          },
+          "limit" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "after" : {
+            "type" : "string"
+          },
+          "sorts" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "filterGroups" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/FilterGroup"
+            }
+          }
+        }
+      },
+      "Error" : {
+        "required" : [ "category", "correlationId", "message" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "string",
+            "description" : "A specific category that contains more specific detail about the error"
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "description" : "Context about the error condition",
+            "example" : {
+              "missingScopes" : [ "scope1", "scope2" ],
+              "invalidPropertyName" : [ "propertyValue" ]
+            }
+          },
+          "correlationId" : {
+            "type" : "string",
+            "description" : "A unique identifier for the request. Include this value with any error reports or support tickets",
+            "format" : "uuid",
+            "example" : "aeb5f871-7f07-4993-9211-075dc63e7cbf"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "description" : "A map of link names to associated URIs containing documentation about the error or recommended remediation steps",
+            "example" : {
+              "knowledge-base" : "https://www.hubspot.com/products/service/knowledge-base"
+            }
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "A human readable message describing the error along with remediation steps where appropriate",
+            "example" : "Invalid input (details will vary based on the error)"
+          },
+          "category" : {
+            "type" : "string",
+            "description" : "The error category",
+            "example" : "VALIDATION_ERROR"
+          },
+          "errors" : {
+            "type" : "array",
+            "description" : "further information about the error",
+            "items" : {
+              "$ref" : "#/components/schemas/ErrorDetail"
+            }
+          }
+        },
+        "example" : {
+          "message" : "Invalid input (details will vary based on the error)",
+          "correlationId" : "aeb5f871-7f07-4993-9211-075dc63e7cbf",
+          "category" : "VALIDATION_ERROR",
+          "links" : {
+            "knowledge-base" : "https://www.hubspot.com/products/service/knowledge-base"
+          }
+        }
+      },
+      "SimplePublicObjectBatchInputUpsert" : {
+        "required" : [ "id", "properties" ],
+        "type" : "object",
+        "properties" : {
+          "idProperty" : {
+            "type" : "string"
+          },
+          "objectWriteTraceId" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "BatchResponseSimplePublicObjectWithErrors" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObject"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "SimplePublicObjectInput" : {
+        "required" : [ "properties" ],
+        "type" : "object",
+        "properties" : {
+          "objectWriteTraceId" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "example" : {
+              "property_date" : "1572480000000",
+              "property_radio" : "option_1",
+              "property_number" : "17",
+              "property_string" : "value",
+              "property_checkbox" : "false",
+              "property_dropdown" : "choice_b",
+              "property_multiple_checkboxes" : "chocolate;strawberry"
+            }
+          }
+        },
+        "example" : {
+          "properties" : {
+            "hs_pipeline" : "Pipeline ID",
+            "hs_order_name" : "Order Name",
+            "hs_total_price" : "100.00",
+            "hs_source_store" : "Store Name",
+            "hs_currency_code" : "USD",
+            "hs_pipeline_stage" : "Pipeline Stage ID",
+            "hs_external_created_date" : "1709814663"
+          },
+          "associations" : [ {
+            "to" : {
+              "id" : "1"
+            },
+            "types" : [ {
+              "associationCategory" : "HUBSPOT_DEFINED",
+              "associationTypeId" : 2
+            } ]
+          } ]
+        }
+      },
+      "CollectionResponseSimplePublicObjectWithAssociationsForwardPaging" : {
+        "required" : [ "results" ],
+        "type" : "object",
+        "properties" : {
+          "paging" : {
+            "$ref" : "#/components/schemas/ForwardPaging"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectWithAssociations"
+            }
+          }
+        }
+      },
+      "AssociationSpec" : {
+        "required" : [ "associationCategory", "associationTypeId" ],
+        "type" : "object",
+        "properties" : {
+          "associationCategory" : {
+            "type" : "string",
+            "enum" : [ "HUBSPOT_DEFINED", "USER_DEFINED", "INTEGRATOR_DEFINED" ]
+          },
+          "associationTypeId" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      },
+      "SimplePublicObjectWithAssociations" : {
+        "required" : [ "createdAt", "id", "properties", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "associations" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/CollectionResponseAssociatedId"
+            }
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "archived" : {
+            "type" : "boolean"
+          },
+          "archivedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "propertiesWithHistory" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/ValueWithTimestamp"
+              }
+            }
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string",
+              "nullable" : true
+            }
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        },
+        "example" : {
+          "properties" : {
+            "createdate" : "2019-10-30T03:30:17.883Z",
+            "hs_currency_code" : "USD",
+            "hs_external_created_date" : "1709814663",
+            "hs_lastmodifieddate" : "2019-12-07T16:50:06.678Z",
+            "hs_order_name" : "Order Name",
+            "hs_pipeline" : "Pipeline ID",
+            "hs_pipeline_stage" : "Pipeline Stage ID",
+            "hs_source_store" : "Store Name",
+            "hs_total_price" : "100.00"
+          }
+        }
+      },
+      "Filter" : {
+        "required" : [ "operator", "propertyName" ],
+        "type" : "object",
+        "properties" : {
+          "highValue" : {
+            "type" : "string"
+          },
+          "propertyName" : {
+            "type" : "string"
+          },
+          "values" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "value" : {
+            "type" : "string"
+          },
+          "operator" : {
+            "type" : "string",
+            "description" : "null",
+            "enum" : [ "EQ", "NEQ", "LT", "LTE", "GT", "GTE", "BETWEEN", "IN", "NOT_IN", "HAS_PROPERTY", "NOT_HAS_PROPERTY", "CONTAINS_TOKEN", "NOT_CONTAINS_TOKEN" ]
+          }
+        }
+      },
+      "BatchInputSimplePublicObjectBatchInput" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectBatchInput"
+            }
+          }
+        }
+      },
+      "BatchInputSimplePublicObjectInputForCreate" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectInputForCreate"
+            }
+          }
+        }
+      },
+      "PreviousPage" : {
+        "required" : [ "before" ],
+        "type" : "object",
+        "properties" : {
+          "before" : {
+            "type" : "string"
+          },
+          "link" : {
+            "type" : "string"
+          }
+        }
+      },
+      "SimplePublicUpsertObject" : {
+        "required" : [ "createdAt", "id", "new", "properties", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "archived" : {
+            "type" : "boolean"
+          },
+          "archivedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "new" : {
+            "type" : "boolean"
+          },
+          "propertiesWithHistory" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/ValueWithTimestamp"
+              }
+            }
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }
+      },
+      "SimplePublicObjectBatchInput" : {
+        "required" : [ "id", "properties" ],
+        "type" : "object",
+        "properties" : {
+          "idProperty" : {
+            "type" : "string",
+            "example" : "my_unique_property_name"
+          },
+          "objectWriteTraceId" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          }
+        },
+        "example" : {
+          "id" : "1",
+          "properties" : {
+            "hs_pipeline" : "Pipeline ID",
+            "hs_order_name" : "Order Name",
+            "hs_total_price" : "100.00",
+            "hs_source_store" : "Store Name",
+            "hs_currency_code" : "USD",
+            "hs_pipeline_stage" : "Pipeline Stage ID",
+            "hs_external_created_date" : "1709814663"
+          }
+        }
+      },
+      "AssociatedId" : {
+        "required" : [ "id", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "NextPage" : {
+        "required" : [ "after" ],
+        "type" : "object",
+        "properties" : {
+          "link" : {
+            "type" : "string",
+            "example" : "?after=NTI1Cg%3D%3D"
+          },
+          "after" : {
+            "type" : "string",
+            "example" : "NTI1Cg%3D%3D"
+          }
+        },
+        "example" : {
+          "after" : "NTI1Cg%3D%3D",
+          "link" : "?after=NTI1Cg%3D%3D"
+        }
+      },
+      "SimplePublicObjectInputForCreate" : {
+        "required" : [ "associations", "properties" ],
+        "type" : "object",
+        "properties" : {
+          "associations" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicAssociationsForObject"
+            }
+          },
+          "objectWriteTraceId" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          }
+        },
+        "example" : {
+          "properties" : {
+            "hs_pipeline" : "Pipeline ID",
+            "hs_order_name" : "Order Name",
+            "hs_total_price" : "100.00",
+            "hs_source_store" : "Store Name",
+            "hs_currency_code" : "USD",
+            "hs_pipeline_stage" : "Pipeline Stage ID",
+            "hs_external_created_date" : "1709814663"
+          },
+          "associations" : [ {
+            "to" : {
+              "id" : "1"
+            },
+            "types" : [ {
+              "associationCategory" : "HUBSPOT_DEFINED",
+              "associationTypeId" : 2
+            } ]
+          } ]
+        }
+      }
+    },
+    "responses" : {
+      "Error" : {
+        "description" : "An error occurred.",
+        "content" : {
+          "*/*" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes" : {
+      "oauth2_legacy" : {
+        "type" : "oauth2",
+        "flows" : {
+          "authorizationCode" : {
+            "authorizationUrl" : "https://app.hubspot.com/oauth/authorize",
+            "tokenUrl" : "https://api.hubapi.com/oauth/v1/token",
+            "scopes" : {
+              "crm.objects.goals.read" : "Read goals",
+              "tickets" : "Read and write tickets",
+              "crm.objects.custom.read" : "View custom object records",
+              "e-commerce" : "e-commerce",
+              "crm.objects.custom.write" : "Change custom object records",
+              "media_bridge.read" : "Read media and media events"
+            }
+          }
+        }
+      },
+      "oauth2" : {
+        "type" : "oauth2",
+        "flows" : {
+          "authorizationCode" : {
+            "authorizationUrl" : "https://app.hubspot.com/oauth/authorize",
+            "tokenUrl" : "https://api.hubapi.com/oauth/v1/token",
+            "scopes" : {
+              "crm.objects.companies.write" : " ",
+              "crm.objects.contacts.write" : " ",
+              "crm.objects.users.write" : "Write User CRM objects",
+              "crm.objects.commercepayments.read" : "Read the COMMERCE_PAYMENT object.",
+              "crm.objects.leads.write" : "Modify lead objects",
+              "crm.objects.subscriptions.read" : "Read Commerce Subscriptions",
+              "crm.objects.carts.read" : "Read carts",
+              "crm.objects.orders.write" : "Write orders",
+              "crm.objects.quotes.read" : "Quotes",
+              "crm.objects.services.read" : "Read services",
+              "crm.objects.orders.read" : "Read Orders",
+              "crm.objects.contacts.read" : " ",
+              "crm.objects.listings.read" : "Read listings",
+              "crm.objects.carts.write" : "Write cart",
+              "crm.objects.courses.write" : "Write courses",
+              "crm.objects.quotes.write" : "Quotes",
+              "crm.objects.users.read" : "Read User CRM objects",
+              "crm.objects.companies.read" : " ",
+              "crm.objects.appointments.read" : "Read appointments",
+              "crm.objects.partner-clients.write" : "Modify Partner Client CRM objects",
+              "crm.objects.leads.read" : "Read lead objects",
+              "crm.objects.appointments.write" : "Write appointments",
+              "crm.objects.services.write" : "Write services",
+              "crm.objects.line_items.read" : "Line Items",
+              "crm.objects.courses.read" : "Read courses",
+              "crm.objects.deals.read" : " ",
+              "crm.objects.invoices.read" : "Read invoices objects",
+              "crm.objects.partner-clients.read" : "View Partner Client CRM objects",
+              "crm.objects.deals.write" : " ",
+              "crm.objects.line_items.write" : "Line Items",
+              "crm.objects.listings.write" : "Write listings"
+            }
+          }
+        }
+      },
+      "private_apps_legacy" : {
+        "type" : "apiKey",
+        "name" : "private-app-legacy",
+        "in" : "header",
+        "x-ballerina-name" : "privateAppLegacy"
+      },
+      "private_apps" : {
+        "type" : "apiKey",
+        "name" : "private-app",
+        "in" : "header",
+        "x-ballerina-name" : "privateApp"
+      }
+    }
+  }
+}

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -1,6 +1,6 @@
 _Author_: @roshanemoraes
 _Created_: 2024/12/18
-_Updated_: 2026/06/17 \\
+_Updated_: 2026/06/17 \
 _Edition_: Swan Lake
 
 # Sanitation for OpenAPI specification

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -1,7 +1,7 @@
-_Author_: @roshanemoraes
-_Created_: 2024/12/18
+_Author_: @roshanemoraes \
+_Created_: 2024/12/18 \
 _Updated_: 2026/06/17 \
-_Edition_: Swan Lake
+_Edition_: Swan Lake \
 
 # Sanitation for OpenAPI specification
 

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -1,6 +1,6 @@
 _Author_: @roshanemoraes
 _Created_: 2024/12/18
-_Updated_: 2024/12/18
+_Updated_: 2026/06/17 \\
 _Edition_: Swan Lake
 
 # Sanitation for OpenAPI specification


### PR DESCRIPTION
Improve operation summaries and add field descriptions

## Purpose

The Ballerina client generator builds doc comments solely from the OpenAPI `summary` field. Previously, only `description` was AI-improved, leaving `summary` fields as terse single words (e.g. "Read", "Archive", "Update") that produced unhelpful doc comments. This PR improves the developer experience by replacing those with concise, meaningful action phrases and adding field-level descriptions to generated types.

Fixes [wso2/product-integrator#1701](https://github.com/wso2/product-integrator/issues/1701)

## Changes

- Replace terse single-word operation summaries in `client.bal` with concise action phrases that accurately describe each operation, e.g. "Read" → "Retrieve a record by ID", "Archive" → "Archive a record by ID", "Update" → "Update a record by ID", "List" → "Retrieve a page of records".

- Condense any overlong summaries to fit the 35-character doc-comment cap.

- Add missing summaries where absent (e.g. search operations).

- Add AI-generated field-level descriptions to `types.bal` to improve generated documentation.

- Refresh `sanitations.md` with updated regeneration timestamp and add `aligned_ballerina_openapi.json` and `flattened_openapi.json` spec artifacts.

## Examples

**Before:**
```ballerina
# Read
resource isolated function get records/[string recordId](...) { }

# Archive
resource isolated function delete records/[string recordId](...) { }

# Update
resource isolated function patch records/[string recordId](...) { }
```

**After:**
```ballerina
# Retrieve a record by ID
resource isolated function get records/[string recordId](...) { }

# Archive a record by ID
resource isolated function delete records/[string recordId](...) { }

# Update a record by ID
resource isolated function patch records/[string recordId](...) { }
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
